### PR TITLE
Remove android deps

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,2 @@
 include ':nspek'
-include ':androsample'
 include ':kotlinsample'


### PR DESCRIPTION
It blocks people from building nspek itself without having android sdk installed.